### PR TITLE
update to scalawiki 0.6.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalaVersion := "2.12.10"
 
 val ScalikejdbcVersion = "3.3.5"
 val ScalikejdbcPlayVersion = "2.6.0-scalikejdbc-3.3"
-val ScalawikiVersion = "0.6.2"
+val ScalawikiVersion = "0.6.3"
 val PlayMailerVersion = "6.0.1"
 
 resolvers += Resolver.bintrayRepo("intracer", "maven")

--- a/test/controllers/AppendImagesSpec.scala
+++ b/test/controllers/AppendImagesSpec.scala
@@ -18,11 +18,11 @@ class AppendImagesSpec extends Specification with Mockito with JuryTestHelpers w
   def image(id: Long) =
     Image(id, s"File:Image$id.jpg", Some(s"url$id"), None, 640, 480, Some(s"12-345-$id"), size = Some(1234))
 
-  def imageInfo(id: Long) = new Page(Some(id), Namespace.FILE, s"File:Image$id.jpg", images = Seq(
+  def imageInfo(id: Long) = new Page(Some(id), Some(Namespace.FILE), s"File:Image$id.jpg", images = Seq(
     new org.scalawiki.dto.Image(s"File:Image$id.jpg", Some(s"url$id"), Some(s"pageUrl$id"), Some(1234), Some(640), Some(480))
   ))
 
-  def revision(id: Long, text: String) = new Page(Some(id), Namespace.FILE, s"File:Image$id.jpg", revisions = Seq(
+  def revision(id: Long, text: String) = new Page(Some(id), Some(Namespace.FILE), s"File:Image$id.jpg", revisions = Seq(
     new Revision(Some(id + 100), Some(id), content = Some(text))
   ))
 

--- a/test/org/intracer/wmua/cmd/FetchImageInfoSpec.scala
+++ b/test/org/intracer/wmua/cmd/FetchImageInfoSpec.scala
@@ -14,7 +14,7 @@ class FetchImageInfoSpec extends Specification with Mockito with JuryTestHelpers
   def contestImage(id: Long, contest: Long) =
     Image(id, s"File:Image$id.jpg", Some(s"url$id"), Some(s"pageUrl$id"), 640, 480, None, size = Some(1234))
 
-  def imageInfo(id: Long) = new Page(Some(id), Namespace.FILE, s"File:Image$id.jpg", images = Seq(
+  def imageInfo(id: Long) = new Page(Some(id), Some(Namespace.FILE), s"File:Image$id.jpg", images = Seq(
     new org.scalawiki.dto.Image(s"File:Image$id.jpg", Some(s"url$id"), Some(s"pageUrl$id"), Some(1234), Some(640), Some(480))
   ))
 

--- a/test/org/intracer/wmua/cmd/FetchImageTextSpec.scala
+++ b/test/org/intracer/wmua/cmd/FetchImageTextSpec.scala
@@ -14,7 +14,7 @@ class FetchImageTextSpec extends Specification with Mockito with JuryTestHelpers
   def contestImage(id: Long, contest: Long) =
     Image(id, s"File:Image$id.jpg", None, None, 0, 0, Some(s"12-345-$id"))
 
-  def revision(id: Long, text: String) = new Page(Some(id), Namespace.FILE, s"File:Image$id.jpg", revisions = Seq(
+  def revision(id: Long, text: String) = new Page(Some(id), Some(Namespace.FILE), s"File:Image$id.jpg", revisions = Seq(
     new Revision(Some(id + 100), Some(id), content = Some(text))
   ))
 


### PR DESCRIPTION
fixes  "A server error occurred: JsError.get" is caused by braces [[ ]] in category name specified in images source input #139
